### PR TITLE
Improve ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v3
       # Checks mcfunction files for errors
       - name: Check commands
-        uses: mcbeet/check-commands@v1.0.6
+        uses: mcbeet/check-commands@v1
         with:
           source: .
           minecraft: 1.18
@@ -50,7 +50,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Run PackSquash
-        uses: ComunidadAylas/PackSquash-action@master
+        uses: ComunidadAylas/PackSquash-action@v3
         with:
           path: ./
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,9 @@
 
 name: CI
 on:
-  # Allows the workflow to be triggered by pushing to master or updating a PR toward master, or manually triggered
+  # Allows the workflow to be triggered by pushing or updating a PR, or manually triggered
   push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
   workflow_dispatch:
 jobs:
   build-main:


### PR DESCRIPTION
Thanks for the great template repository. Please forgive me for ignoring the comment.

- It isn't good to default to restricting to run on master only. Only people who don't want to run in other branches should set branches or branches-ignore.
- mcbeet/check-commands has a v1 tag that can automatically use a compatible and better version.
- PackSquash-action@master may be unstable, so v3 is better.