### PR TITLE
Update for Minecraft 1.20 and PackSquash-action@v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,13 +50,10 @@ jobs:
         with:
           fetch-depth: 0
       - name: Run PackSquash
-        uses: ComunidadAylas/PackSquash-action@v3
+        uses: ComunidadAylas/PackSquash-action@v4
         with:
-          path: ./
-          token: ${{ secrets.GITHUB_TOKEN }}
-          minify_json_files: true
-          validate_pack_metadata_file: true
-          allow_optifine_mod: true
-          delete_bloat_json_keys: true
           artifact_name: '[UNZIP ME] your-datapack v1'
-  
+          packsquash_version: latest
+          options: |
+            pack_directory = '.'
+            allow_mods = ['OptiFine']

--- a/README.md
+++ b/README.md
@@ -32,14 +32,16 @@ The `pack.mcmeta` file is what tells Minecraft what version of Minecraft your pa
 The `pack_format` key is what tells Minecraft what version of Minecraft your pack is made for. In most cases, datapacks will work in a version greater than the version it was made for, but not always the other way around. Here's a handy table:
 
 | Minecraft version | `pack_format` |
-| ----------------- | ------------- |
+|-------------------|---------------|
 | 1.13 - 1.14.4     | 4             |
 | 1.15 - 1.16.1     | 5             |
 | 1.16.2 - 1.16.5   | 6             |
 | 1.17 - 1.17.1     | 7             |
 | 1.18 - 1.18.1     | 8             |
 | 1.18.2            | 9             |
-| 1.19+             | 10            |
+| 1.19 - 1.19.3     | 10            |
+| 1.19.4            | 12            |
+| 1.20.0+           | 15            |
 
 Sample `pack.mcmeta` (you can also see in the example datapack [here](pack.mcmeta)):
 


### PR DESCRIPTION
v4.0.0 of the PackSquash GitHub Action was just released, so I figured it would be a good idea to update this awesome template to use it! :tada: The complete changelog is available [here](https://github.com/ComunidadAylas/PackSquash-action/blob/master/CHANGELOG.md#400---2023-06-25).

While at it, I've also updated the documentation to also mention Minecraft 1.20. I didn't update the mcbeet/check-commands action input parameters because I'm not sure whether it officially supports 1.20 yet.